### PR TITLE
Allow __sort to come in as an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ module.exports = function qpm(opts) {
 		var sort;
 		if (params.__sort) {
 			sort = {};
-			var sortSpecs = params.__sort.split(',');
+			var sortSpecs = typeof params.__sort === 'string' ? params.__sort.split(',') : params.__sort;
 			sortSpecs.forEach(function(s) {
 				var direction = 1;
 				var sortField = s;


### PR DESCRIPTION
Hello there! Love your library, I've been using it for quite some time and it's helped me a lot.

However, I just found that when I specify __sort in two different parts of my query it throws an exception since it can't find the split method in the array that genertes. Here is the example I was using in my API:

`/api/v1/items?visible=true&__sort=priority&collections=5c548da4e98f08231da8d88c&__limit=15&__offset=0&__sort=sold`

The reason why I didn't want to do __sort=priority,sold is actually a valid one, I think... It is that the url is put together by my application in different modules, visible=true&__sort=priority are two query params that must be a part of all urls, so I add them in my redux thunk action in my client. The rest is added in the function I put in my component props.

As of now I was able to make things work by adding this bit of code in my server:

```typescript
// HACK: qpm cannot handle __sort as an array, it expects a comma separated string
if (typeof query['__sort'] === 'object')
  query['__sort'] = `${query['__sort']}`;
```

Unless this is expected behavior please consider this. Should you find anything wrong with what I did (which I wouldn't be surprised if you did given how fast I wrote it 😬) let me know.

Thanks again for the lib!