### PR TITLE
fix defaultAutoDetectTypes valuePattern for dataType bool

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var defaultAutoDetectTypes = [
 	{ fieldPattern: /_date$/, dataType: 'date' },
 	{ valuePattern: /^[0-9]+$/, dataType: 'int' } ,
 	{ valuePattern: /^[0-9]*\.[0-9]+$/, dataType: 'float' } ,
-	{ valuePattern: /^true|false|yes|no$/i, dataType: 'bool' } ,
+	{ valuePattern: /^(true|false|yes|no)$/i, dataType: 'bool' } ,
 	{ valuePattern: /^[0-9][0-9-: ]+$/, dataType: 'date' } ,
 ];
 


### PR DESCRIPTION
The previous regex for data type `bool` matches string that contains `true|false|yes|no`

e.g:
id `VDHDNo` will be detected as boolean which return `false` instead of the inputted string